### PR TITLE
Add shipping class ID columns

### DIFF
--- a/src/lib/db/migrations/0001_add_shipping_class_id.sql
+++ b/src/lib/db/migrations/0001_add_shipping_class_id.sql
@@ -1,0 +1,3 @@
+ALTER TABLE products   ADD COLUMN IF NOT EXISTS shipping_class_id INTEGER;
+ALTER TABLE variations ADD COLUMN IF NOT EXISTS shipping_class_id INTEGER;
+

--- a/src/lib/db/migrations/meta/_journal.json
+++ b/src/lib/db/migrations/meta/_journal.json
@@ -8,6 +8,13 @@
       "when": 1754314562386,
       "tag": "0000_equal_swarm",
       "breakpoints": true
+    },
+    {
+      "idx": 1,
+      "version": "7",
+      "when": 1754330892618,
+      "tag": "0001_add_shipping_class_id",
+      "breakpoints": true
     }
   ]
 }


### PR DESCRIPTION
## Summary
- add migration to append shipping_class_id columns to products and variations
- register migration in journal

## Testing
- `npm run migrate` (fails: Missing script "migrate")
- `npm run db:migrate` (fails: connect ECONNREFUSED ::1:5432)
- `npm test` (fails: No tests found, exiting with code 1)
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6890f66bef4c8333af79aaaebd1ef1ed