### PR TITLE
feat: show product shop availability

### DIFF
--- a/src/app/products/page.tsx
+++ b/src/app/products/page.tsx
@@ -37,6 +37,14 @@ interface Product {
   images: any[]
   attributes: any[]
   variations: any[]
+  productShops?: {
+    shopId: number
+    priceOverride?: string | null
+    shop?: {
+      id: number
+      name: string
+    }
+  }[]
   variationsCount?: number
   dateCreated: string
   dateModified: string
@@ -50,6 +58,7 @@ interface ProductFilters {
   status?: string
   stockStatus?: string
   type?: string
+  inShopId?: number
   sortBy?: 'name' | 'price' | 'dateCreated' | 'dateModified' | 'sku'
   sortOrder?: 'asc' | 'desc'
 }
@@ -74,6 +83,10 @@ export default function ProductsPage() {
   const { shops } = useShops()
   const { toast } = useToast()
   const { products, isLoading, error, currentPage, totalPages, total, hasMore, goToPage, loadMore, mutate } = useProducts(searchTerm, 25, filters)
+
+  const filteredProducts = filters.inShopId
+    ? (products || []).filter(p => p.productShops?.some(ps => ps.shopId === filters.inShopId))
+    : products || []
 
   // Auto-select first shop if none selected
   useEffect(() => {
@@ -260,6 +273,7 @@ export default function ProductsPage() {
             onFiltersChange={setFilters}
             categories={categories}
             brands={brands}
+            shops={shops.filter(s => s.id !== selectedShop.id)}
           />
 
           {/* Pagination Mode Toggle */}
@@ -306,7 +320,7 @@ export default function ProductsPage() {
 
       {/* Products List/Grid */}
       <ProductList
-        products={products || []}
+        products={filteredProducts}
         isLoading={isLoading}
         error={error}
         viewMode={viewMode}

--- a/src/components/products/product-card.tsx
+++ b/src/components/products/product-card.tsx
@@ -308,6 +308,20 @@ export function ProductCard({ product, isOpen, onClose, onUpdate }: ProductCardP
                     )}
                   </div>
 
+                  {product?.productShops?.length ? (
+                    <div>
+                      <Label>Shops</Label>
+                      <div className="flex flex-wrap gap-1 mt-1">
+                        {product.productShops.map((ps: any) => (
+                          <Badge key={ps.shopId} variant="secondary">
+                            {ps.shop?.name}
+                            {ps.priceOverride ? ` (${ps.priceOverride})` : ''}
+                          </Badge>
+                        ))}
+                      </div>
+                    </div>
+                  ) : null}
+
                   <div>
                     <Label htmlFor="description">Description</Label>
                     {isEditing ? (

--- a/src/components/products/product-filters.tsx
+++ b/src/components/products/product-filters.tsx
@@ -3,7 +3,6 @@
 import { useState, useEffect } from 'react'
 import { Filter, X, ChevronDown } from 'lucide-react'
 import { Button } from '../ui/button'
-import { Input } from '../ui/input'
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '../ui/select'
 import { Badge } from '../ui/badge'
 import { Card, CardContent, CardHeader, CardTitle } from '../ui/card'
@@ -14,6 +13,7 @@ interface ProductFilters {
   status?: string
   stockStatus?: string
   type?: string
+  inShopId?: number
   sortBy?: 'name' | 'price' | 'dateCreated' | 'dateModified' | 'sku'
   sortOrder?: 'asc' | 'desc'
 }
@@ -23,13 +23,15 @@ interface ProductFiltersProps {
   onFiltersChange: (filters: ProductFilters) => void
   categories: string[]
   brands: string[]
+  shops?: { id: number; name: string }[]
 }
 
-export function ProductFilters({ 
-  filters, 
-  onFiltersChange, 
-  categories = [], 
-  brands = [] 
+export function ProductFilters({
+  filters,
+  onFiltersChange,
+  categories = [],
+  brands = [],
+  shops = []
 }: ProductFiltersProps) {
   const [isOpen, setIsOpen] = useState(false)
   const [localFilters, setLocalFilters] = useState<ProductFilters>(filters)
@@ -38,8 +40,8 @@ export function ProductFilters({
     setLocalFilters(filters)
   }, [filters])
 
-  const handleFilterChange = (key: keyof ProductFilters, value: string | undefined) => {
-    const newFilters = { ...localFilters, [key]: value || undefined }
+  const handleFilterChange = (key: keyof ProductFilters, value: string | number | undefined) => {
+    const newFilters = { ...localFilters, [key]: value !== '' ? value : undefined }
     setLocalFilters(newFilters)
   }
 
@@ -226,6 +228,29 @@ export function ProductFilters({
                 </SelectContent>
               </Select>
             </div>
+
+            {/* Exists In Shop Filter */}
+            {shops.length > 0 && (
+              <div className="space-y-2">
+                <label className="text-sm font-medium">Exists In Shop</label>
+                <Select
+                  value={localFilters.inShopId ? localFilters.inShopId.toString() : 'all'}
+                  onValueChange={(value) => handleFilterChange('inShopId', value === 'all' ? undefined : Number(value))}
+                >
+                  <SelectTrigger>
+                    <SelectValue placeholder="All shops" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="all">All shops</SelectItem>
+                    {shops.map((shop) => (
+                      <SelectItem key={shop.id} value={shop.id.toString()}>
+                        {shop.name}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+            )}
 
             {/* Action Buttons */}
             <div className="flex gap-2 pt-4">

--- a/src/components/products/product-list.tsx
+++ b/src/components/products/product-list.tsx
@@ -45,6 +45,14 @@ interface Product {
   images: any[]
   attributes: any[]
   variations: any[]
+  productShops?: {
+    shopId: number
+    priceOverride?: string | null
+    shop?: {
+      id: number
+      name: string
+    }
+  }[]
   variationsCount?: number
   dateCreated: string
   dateModified: string
@@ -510,6 +518,18 @@ function ProductGridItem({ product, onSelect, isSelected = false, onToggleSelect
               )}
             </div>
 
+            {/* Shop Badges */}
+            {product.productShops?.length ? (
+              <div className="flex flex-wrap gap-1">
+                {product.productShops.map(ps => (
+                  <Badge key={ps.shopId} variant="secondary" className="text-xs">
+                    {ps.shop?.name}
+                    {ps.priceOverride ? ` (${ps.priceOverride})` : ''}
+                  </Badge>
+                ))}
+              </div>
+            ) : null}
+
             {/* Status Badges */}
             <div className="flex flex-wrap gap-1">
               <Badge className={`text-xs ${statusColors[product.status as keyof typeof statusColors]}`}>
@@ -661,6 +681,17 @@ function ProductListItem({ product, onSelect, isSelected = false, onToggleSelect
                     {product.categories.map(c => c.name).join(', ')}
                   </p>
                 )}
+
+                {product.productShops?.length ? (
+                  <div className="flex flex-wrap gap-1 mt-1">
+                    {product.productShops.map(ps => (
+                      <Badge key={ps.shopId} variant="secondary" className="text-xs">
+                        {ps.shop?.name}
+                        {ps.priceOverride ? ` (${ps.priceOverride})` : ''}
+                      </Badge>
+                    ))}
+                  </div>
+                ) : null}
               </div>
 
               {/* Price */}

--- a/src/lib/hooks/use-products.ts
+++ b/src/lib/hooks/use-products.ts
@@ -2,6 +2,15 @@ import { useState, useEffect } from 'react'
 import useSWR from 'swr'
 import { useAppStore } from '../store'
 
+interface ProductShop {
+  shopId: number
+  priceOverride?: string | null
+  shop?: {
+    id: number
+    name: string
+  }
+}
+
 interface Product {
   id: number
   shopId: number
@@ -22,6 +31,7 @@ interface Product {
   images: any[]
   attributes: any[]
   variations: any[]
+  productShops?: ProductShop[]
   dateCreated: string
   dateModified: string
   createdAt: string
@@ -42,6 +52,7 @@ interface ProductFilters {
   status?: string
   stockStatus?: string
   type?: string
+  inShopId?: number
   sortBy?: 'name' | 'price' | 'dateCreated' | 'dateModified' | 'sku'
   sortOrder?: 'asc' | 'desc'
 }
@@ -91,7 +102,10 @@ export function useProducts(search: string = '', limit: number = 25, filters: Pr
     if (filters.sortOrder) {
       params.append('sortOrder', filters.sortOrder)
     }
-    
+
+    // Include related shops information
+    params.append('include', 'productShops')
+
     return `/api/products?${params.toString()}`
   }
 


### PR DESCRIPTION
## Summary
- include productShops relations in useProducts
- render shop and price badges on product cards and lists
- allow filtering by products available in another shop

## Testing
- `npm test -- --passWithNoTests`
- `npm run lint`
- `npm run type-check`


------
https://chatgpt.com/codex/tasks/task_e_6891e96773508333837b942d4c36e7aa