### PR TITLE
Fix login sync and map product stock fields

### DIFF
--- a/src/app/api/auth/login/route.ts
+++ b/src/app/api/auth/login/route.ts
@@ -30,6 +30,7 @@ export async function POST(request: NextRequest) {
         email: user.email,
         username: user.username,
         autoSync: user.autoSync,
+        lastLogin: user.lastLogin,
       },
     })
   } catch (error) {

--- a/src/app/api/products/route.ts
+++ b/src/app/api/products/route.ts
@@ -77,6 +77,8 @@ export async function GET(request: NextRequest) {
       id: row.shopData.id,
       price: row.shopData.price,
       category: row.shopData.category,
+      stockQuantity: row.shopData.stockQuantity,
+      stockStatus: row.shopData.stockStatus,
       isActive: row.shopData.isActive,
       masterProductId: row.shopData.masterProductId,
       shopId: row.shopData.shopId,
@@ -104,7 +106,7 @@ export async function GET(request: NextRequest) {
 export async function POST(request: NextRequest) {
   try {
     const body = await request.json()
-    const { shopId, sku, name, description, price, category, isActive } = body
+    const { shopId, sku, name, description, price, category, isActive, stockQuantity, stockStatus } = body
 
     if (!shopId) {
       return NextResponse.json({ error: 'Shop ID is required' }, { status: 400 })
@@ -137,6 +139,8 @@ export async function POST(request: NextRequest) {
         shopId,
         price,
         category,
+        stockQuantity,
+        stockStatus: stockStatus || 'instock',
         isActive: isActive ?? true,
       })
       .onConflictDoUpdate({
@@ -144,6 +148,8 @@ export async function POST(request: NextRequest) {
         set: {
           price,
           category,
+          stockQuantity,
+          stockStatus: stockStatus || 'instock',
           isActive: isActive ?? true,
           updatedAt: new Date(),
         },
@@ -157,6 +163,8 @@ export async function POST(request: NextRequest) {
         shopId: shopProduct.shopId,
         price: shopProduct.price,
         category: shopProduct.category,
+        stockQuantity: shopProduct.stockQuantity,
+        stockStatus: shopProduct.stockStatus,
         isActive: shopProduct.isActive,
         sku: master.sku,
         name: master.name,

--- a/src/app/api/products/sync/route.ts
+++ b/src/app/api/products/sync/route.ts
@@ -83,6 +83,8 @@ export async function POST(request: NextRequest) {
           shopId: shopIdNum,
           price: wooProduct.price || wooProduct.regular_price || null,
           category: wooProduct.categories?.[0]?.name || null,
+          stockQuantity: wooProduct.stock_quantity || null,
+          stockStatus: wooProduct.stock_status,
           isActive: wooProduct.status === 'publish',
           updatedAt: new Date(),
         }

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -135,10 +135,11 @@ export async function authenticateUser(emailOrUsername: string, password: string
     return null
   }
 
-  // Update last login
+  // Update last login and return fresh user data
+  const now = new Date()
   await db
     .update(users)
-    .set({ lastLogin: new Date() })
+    .set({ lastLogin: now, updatedAt: now })
     .where(eq(users.id, user.id))
 
   return {
@@ -147,9 +148,9 @@ export async function authenticateUser(emailOrUsername: string, password: string
     username: user.username,
     isActive: user.isActive,
     autoSync: user.autoSync,
-    lastLogin: user.lastLogin,
+    lastLogin: now,
     createdAt: user.createdAt,
-    updatedAt: user.updatedAt,
+    updatedAt: now,
   }
 }
 

--- a/src/lib/db/migrations/add_product_shops_stock.sql
+++ b/src/lib/db/migrations/add_product_shops_stock.sql
@@ -1,0 +1,3 @@
+-- Add stock columns to product_shops
+ALTER TABLE product_shops ADD COLUMN IF NOT EXISTS stock_quantity INTEGER;
+ALTER TABLE product_shops ADD COLUMN IF NOT EXISTS stock_status VARCHAR(20) DEFAULT 'instock';

--- a/src/lib/db/schema.ts
+++ b/src/lib/db/schema.ts
@@ -158,6 +158,8 @@ export const productShops = pgTable(
       .notNull(),
     price: decimal('price', { precision: 10, scale: 2 }),
     category: varchar('category', { length: 255 }),
+    stockQuantity: integer('stock_quantity'),
+    stockStatus: varchar('stock_status', { length: 20 }).default('instock'),
     isActive: boolean('is_active').default(true).notNull(),
     createdAt: timestamp('created_at').defaultNow().notNull(),
     updatedAt: timestamp('updated_at').defaultNow().notNull(),


### PR DESCRIPTION
## Summary
- ensure last login timestamp updates correctly and is returned to client
- map WooCommerce stock fields to product shops table and APIs
- add database migration for new stock columns

## Testing
- `npm test -- --passWithNoTests`
- `npm run lint`
- `npm run type-check` *(fails: Cannot find module '../../../../lib/db' ...)*

------
https://chatgpt.com/codex/tasks/task_e_6891f26e00d48333840a4486eba8ca15